### PR TITLE
Add web app for call tracking

### DIFF
--- a/Auth.gs
+++ b/Auth.gs
@@ -1,0 +1,53 @@
+var CACHE_TTL = 30*60; // 30 minutos
+var SPREAD_ID = '1uALb5eB_AU6CjRNfvUKUFycgnNm5K3phMpxsQfZITyY';
+
+// Valida usuario y almacena sesion
+function validarUsuario(email, dni){
+  email = (email || '').toString().trim().toLowerCase();
+  dni = (dni || '').toString().trim();
+  var ss = SpreadsheetApp.openById(SPREAD_ID);
+  var sheet = ss.getSheetByName('Evaluadores');
+  var data = sheet.getDataRange().getValues();
+  for(var i=1;i<data.length;i++){
+    if(data[i][0].toString().toLowerCase()==email && data[i][1].toString()==dni){
+      var usuario = {
+        correo: data[i][0],
+        dni: data[i][1],
+        rol: data[i][2],
+        nombres: data[i][3],
+        apellidos: data[i][4],
+        coordinador: data[i][5]
+      };
+      CacheService.getUserCache().put('session', JSON.stringify(usuario), CACHE_TTL);
+      logAcceso(usuario);
+      return {ok:true, usuario:usuario};
+    }
+  }
+  return {ok:false};
+}
+
+// Obtiene sesion almacenada
+function getSession(){
+  var cache = CacheService.getUserCache().get('session');
+  if(cache){
+    return JSON.parse(cache);
+  }
+  return null;
+}
+
+// Cierra sesion
+function cerrarSesion(){
+  CacheService.getUserCache().remove('session');
+  return true;
+}
+
+// Registra accesos
+function logAcceso(usuario){
+  var ss = SpreadsheetApp.openById(SPREAD_ID);
+  var sheet = ss.getSheetByName('Log_Sesiones');
+  if(!sheet){
+    sheet = ss.insertSheet('Log_Sesiones');
+    sheet.appendRow(['Fecha','Correo','DNI','Rol','UserAgent']);
+  }
+  sheet.appendRow([new Date(), usuario.correo, usuario.dni, usuario.rol, Session.getActiveUser().getEmail()]);
+}

--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,21 @@
+// Controlador principal
+function doGet(e){
+  var session = getSession();
+  var template;
+  if(session){
+    template = HtmlService.createTemplateFromFile('Index');
+    template.usuario = session;
+  }else{
+    template = HtmlService.createTemplateFromFile('Login');
+  }
+  var html = template.evaluate()
+    .setTitle('Seguimiento de Llamadas')
+    .addMetaTag('viewport','width=device-width, initial-scale=1');
+  html.addMetaTag('X-Frame-Options','SAMEORIGIN');
+  return html;
+}
+
+// Permite incluir archivos HTML
+function include(nombre){
+  return HtmlService.createHtmlOutputFromFile(nombre).getContent();
+}

--- a/Estadisticas.gs
+++ b/Estadisticas.gs
@@ -1,0 +1,23 @@
+var SPREAD_ID = '1uALb5eB_AU6CjRNfvUKUFycgnNm5K3phMpxsQfZITyY';
+
+// Retorna datos agregados para graficos
+function datosEstadisticas(){
+  var usuario = getSession();
+  if(!usuario || usuario.rol!='Coordinador') return null;
+  var ss = SpreadsheetApp.openById(SPREAD_ID);
+  var llamadas = ss.getSheetByName('Llamadas');
+  if(!llamadas) return [];
+  var data = llamadas.getDataRange().getValues();
+  var totales = {};
+  for(var i=1;i<data.length;i++){
+    var monitor = data[i][1];
+    totales[monitor] = totales[monitor] || {total:0, efectivas:0};
+    totales[monitor].total++;
+    if(data[i][4]=='SI') totales[monitor].efectivas++;
+  }
+  var result = [];
+  for(var m in totales){
+    result.push([m, totales[m].total, totales[m].efectivas]);
+  }
+  return result;
+}

--- a/Estadisticas.html
+++ b/Estadisticas.html
@@ -1,0 +1,25 @@
+<div class="contenido" id="estadisticas">
+  <p>Solo coordinadores pueden ver las estadísticas.</p>
+  <div id="chart_div" style="width:100%;height:400px"></div>
+</div>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded',function(){
+    if(usuario.rol!='Coordinador'){document.getElementById('estadisticas').innerHTML='No autorizado';return;}
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(drawChart);
+  });
+
+  function drawChart(){
+    google.script.run.withSuccessHandler(function(res){
+      if(!res) return;
+      var data=new google.visualization.DataTable();
+      data.addColumn('string','Monitor');
+      data.addColumn('number','Total');
+      data.addColumn('number','Efectivas');
+      data.addRows(res);
+      var chart=new google.visualization.ColumnChart(document.getElementById('chart_div'));
+      chart.draw(data,{title:'Llamadas por monitor',colors:['#1976D2','#FFC107']});
+    }).datosEstadisticas();
+  }
+</script>

--- a/Index.html
+++ b/Index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <style>
+      body{background:#F5F5F5;font-family:'Roboto',sans-serif;}
+      .header{background:#0D47A1;color:white;padding:10px;display:flex;justify-content:space-between;align-items:center;}
+      .tabs{width:100%;}
+      .contenido{padding:20px;}
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <div><svg height="32" viewBox="0 0 24 24" fill="#FFC107"><path d="M12 2L1.5 21h21L12 2z"/></svg> Seguimiento</div>
+      <button class="mdl-button mdl-js-button mdl-button--raised" onclick="logout()">Cerrar sesión</button>
+    </div>
+    <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect tabs">
+      <div class="mdl-tabs__tab-bar">
+        <a href="#tab1" class="mdl-tabs__tab is-active">Seguimiento de llamadas</a>
+        <a href="#tab2" class="mdl-tabs__tab">Estadísticas</a>
+        <a href="#tab3" class="mdl-tabs__tab">Próximamente</a>
+      </div>
+      <div class="mdl-tabs__panel is-active" id="tab1">
+        <?!= include('Seguimiento'); ?>
+      </div>
+      <div class="mdl-tabs__panel" id="tab2">
+        <?!= include('Estadisticas'); ?>
+      </div>
+      <div class="mdl-tabs__panel" id="tab3">
+        <div class="contenido">Próximamente</div>
+      </div>
+    </div>
+    <script>
+      var usuario = <?= JSON.stringify(usuario) ?>;
+      function logout(){
+        google.script.run.withSuccessHandler(function(){location.reload();}).cerrarSesion();
+      }
+    </script>
+  </body>
+</html>

--- a/Login.html
+++ b/Login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-blue.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+    <style>
+      body{background:#F5F5F5;font-family:'Roboto',sans-serif;display:flex;justify-content:center;align-items:center;height:100vh;}
+      .card{padding:20px;background:white;border-radius:4px;}
+    </style>
+  </head>
+  <body>
+    <div class="card mdl-shadow--2dp">
+      <h4>Ingreso</h4>
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="email" id="email">
+        <label class="mdl-textfield__label" for="email">Correo</label>
+      </div>
+      <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label">
+        <input class="mdl-textfield__input" type="text" id="dni">
+        <label class="mdl-textfield__label" for="dni">DNI</label>
+      </div>
+      <button class="mdl-button mdl-js-button mdl-button--raised" onclick="login()">Entrar</button>
+      <div id="snackbar" class="mdl-js-snackbar mdl-snackbar"></div>
+    </div>
+    <script>
+      function login(){
+        var email = document.getElementById('email').value;
+        var dni = document.getElementById('dni').value;
+        google.script.run.withSuccessHandler(function(res){
+          if(res && res.ok){
+            location.reload();
+          }else{
+            var sb = document.getElementById('snackbar');
+            sb.MaterialSnackbar.showSnackbar({message:'Credenciales incorrectas'});
+          }
+        }).validarUsuario(email,dni);
+      }
+    </script>
+  </body>
+</html>

--- a/Seguimiento.gs
+++ b/Seguimiento.gs
@@ -1,0 +1,61 @@
+> var SPREAD_ID = '1uALb5eB_AU6CjRNfvUKUFycgnNm5K3phMpxsQfZITyY';
+> 
+> // Obtiene resumen para coordinador segun periodo en dias
+> function obtenerResumen(periodo){
+>   var usuario = getSession();
+>   if(!usuario) return null;
+>   var ss = SpreadsheetApp.openById(SPREAD_ID);
+>   var llamadas = ss.getSheetByName('Llamadas');
+>   if(!llamadas){
+>     llamadas = ss.insertSheet('Llamadas');
+>     llamadas.appendRow(['Timestamp','Monitor','DNI','Estado','Efectiva','Motivo','Obs']);
+>   }
+>   var datos = llamadas.getDataRange().getValues();
+>   var limites = new Date(new Date().getTime()-periodo*24*60*60*1000);
+>   var resumen = {};
+>   for(var i=1;i<datos.length;i++){
+>     var f = datos[i][0];
+>     if(f>=limites){
+>       var m = datos[i][1];
+>       resumen[m] = resumen[m] || {total:0, contestadas:0, efectivas:0, min:0};
+>       resumen[m].total++;
+>       if(datos[i][3]=='SI') resumen[m].contestadas++;
+>       if(datos[i][4]=='SI') resumen[m].efectivas++;
+>     }
+>   }
+>   var result = [];
+>   for(var monitor in resumen){
+>     result.push([monitor,resumen[monitor].total,resumen[monitor].contestadas,resumen[monitor].efectivas,'-']);
+>   }
+>   return result;
+> }
+> 
+> // Obtiene casos asignados a monitor
+> function obtenerCasos(){
+>   var usuario = getSession();
+>   if(!usuario) return null;
+>   var ss = SpreadsheetApp.openById(SPREAD_ID);
+>   var sheet = ss.getSheetByName('Muestra');
+>   var data = sheet.getDataRange().getValues();
+>   var res = [];
+>   for(var i=1;i<data.length;i++){
+>     if(data[i][5]==usuario.dni){
+>       res.push({dni:data[i][0], nombre:data[i][1], telefono:data[i][2], intentos:data[i][3], estado:data[i][4]});
+>     }
+>   }
+>   return res;
+> }
+> 
+> // Guarda llamada
+> function guardarLlamada(reg){
+>   var usuario = getSession();
+>   if(!usuario) return {ok:false};
+>   var ss = SpreadsheetApp.openById(SPREAD_ID);
+>   var sheet = ss.getSheetByName('Llamadas');
+>   if(!sheet){
+>     sheet = ss.insertSheet('Llamadas');
+>     sheet.appendRow(['Timestamp','Monitor','DNI','Contestada','Efectiva','Motivo','Obs']);
+>   }
+>   sheet.appendRow([new Date(), usuario.dni, reg.dni, reg.contestada, reg.efectiva, reg.motivo, reg.obs]);
+>   return {ok:true};
+> }

--- a/Seguimiento.html
+++ b/Seguimiento.html
@@ -1,0 +1,58 @@
+<div class="contenido">
+  <div id="vistaMonitor" style="display:none;">
+    <table class="mdl-data-table mdl-js-data-table" id="tablaCasos">
+      <thead>
+        <tr><th>DNI</th><th>Nombre</th><th>Teléfono</th><th>#Intentos</th><th>Estado</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <div id="vistaCoord" style="display:none;">
+    <select id="periodo" onchange="cargarResumen()">
+      <option value="1">24h</option>
+      <option value="7">7 días</option>
+      <option value="30">30 días</option>
+      <option value="365">Todo</option>
+    </select>
+    <table class="mdl-data-table mdl-js-data-table" id="tablaResumen">
+      <thead><tr><th>Monitor</th><th>Total</th><th>Contestadas</th><th>Efectivas</th><th>Prom. min en app</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded',function(){
+    if(usuario.rol=='Coordinador'){
+      document.getElementById('vistaCoord').style.display='block';
+      cargarResumen();
+    }else{
+      document.getElementById('vistaMonitor').style.display='block';
+      cargarCasos();
+    }
+  });
+
+  function cargarCasos(){
+    google.script.run.withSuccessHandler(function(data){
+      var tbody=document.querySelector('#tablaCasos tbody');
+      tbody.innerHTML='';
+      data.forEach(function(r){
+        var tr=document.createElement('tr');
+        tr.innerHTML='<td>'+r.dni+'</td><td>'+r.nombre+'</td><td>'+r.telefono+'</td><td>'+r.intentos+'</td><td>'+r.estado+'</td>';
+        tbody.appendChild(tr);
+      });
+    }).obtenerCasos();
+  }
+
+  function cargarResumen(){
+    var p=document.getElementById('periodo').value;
+    google.script.run.withSuccessHandler(function(data){
+      var tbody=document.querySelector('#tablaResumen tbody');
+      tbody.innerHTML='';
+      data.forEach(function(r){
+        var tr=document.createElement('tr');
+        tr.innerHTML='<td>'+r[0]+'</td><td>'+r[1]+'</td><td>'+r[2]+'</td><td>'+r[3]+'</td><td>'+r[4]+'</td>';
+        tbody.appendChild(tr);
+      });
+    }).obtenerResumen(parseInt(p));
+  }
+</script>

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1,0 +1,9 @@
+<aside style="padding:10px;background:#EEE">
+  <h5>Actividad reciente</h5>
+  <div id="resumen"></div>
+</aside>
+<script>
+  google.script.run.withSuccessHandler(function(res){
+    document.getElementById('resumen').innerText=res;
+  }).dummy=function(){return '';};
+</script>


### PR DESCRIPTION
## Summary
- add main controller and utilities for Apps Script web app
- implement authentication, call tracking and statistics
- add frontend views with Material Design Lite

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868e3eaf9e0832d88c2c137a4fde955